### PR TITLE
feat: Add more standard method names for NEP-177

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -118,6 +118,31 @@ export const interfaces: Readonly<
         name: 'nft_metadata',
         args: [],
       },
+      {
+        name: 'nft_token',
+        args: [
+          { name: 'token_id', type: 'string' },
+        ],
+      },
+      {
+        name: 'nft_transfer',
+        args: [
+          { name: 'receiver_id', type: 'string' },
+          { name: 'token_id', type: 'string' },
+          { name: 'approval_id', type: ['string', 'null'] },
+          { name: 'memo', type: ['string', 'null'] },
+        ],
+      },
+      {
+        name: 'nft_transfer_call',
+        args: [
+          { name: 'receiver_id', type: 'string' },
+          { name: 'token_id', type: 'string' },
+          { name: 'approval_id', type: ['string', 'null'] },
+          { name: 'memo', type: ['string', 'null'] },
+          { name: 'msg', type: 'string' },
+        ],
+      },
     ],
   },
   [StandardInterfaceId.NEP178]: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -120,9 +120,7 @@ export const interfaces: Readonly<
       },
       {
         name: 'nft_token',
-        args: [
-          { name: 'token_id', type: 'string' },
-        ],
+        args: [{ name: 'token_id', type: 'string' }],
       },
       {
         name: 'nft_transfer',


### PR DESCRIPTION
Add three more interfaces for NEP-177 https://nomicon.io/Standards/NonFungibleToken/Core.html
- nft_token
- nft_transfer
- nft_transfer_call

I edited this file in the GitHub editor, so I'm not sure if the format is 100% correct.